### PR TITLE
makes it possible to use local configuration

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -64,6 +64,7 @@ class CKEditor extends InputWidget
         $cdnBaseUrl = self::$cdnBaseUrl;
         $encodedOptions = !empty($this->clientOptions) ? Json::htmlEncode($this->clientOptions) : '{}';
 
+        $view->registerJs("var CKEDITOR_BASEPATH = '$cdnBaseUrl';", View::POS_HEAD);
         $view->registerJs("alexantr.ckEditorWidget.setBaseUrl('$cdnBaseUrl');", View::POS_END);
         $view->registerJs("alexantr.ckEditorWidget.register('$id', $encodedOptions);", View::POS_END);
         if (isset($this->clientOptions['filebrowserUploadUrl']) || isset($this->clientOptions['filebrowserImageUploadUrl'])) {


### PR DESCRIPTION
Allows to use CKEditor from your own CDN (for example, localy). This is useful for connecting third-party plugins (for example, the Youtube Plugin).
https://ckeditor.com/docs/ckeditor4/latest/guide/dev_basepath.html#solution-ckeditor_basepath